### PR TITLE
Send API requests on UI actions

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -52,3 +52,5 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
     implementation "androidx.cardview:cardview:1.0.0"
 }
+
+apply plugin: "androidx.navigation.safeargs"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     // used for API requests
     implementation 'com.squareup.retrofit2:retrofit:2.4.0'
     implementation 'com.squareup.retrofit2:converter-gson:2.4.0'
+    implementation 'com.squareup.okhttp3:okhttp:4.9.1'
     implementation 'com.squareup.okhttp3:logging-interceptor:4.9.1'
 
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.1'

--- a/app/src/main/java/com/helio/app/MainActivity.java
+++ b/app/src/main/java/com/helio/app/MainActivity.java
@@ -71,177 +71,177 @@ public class MainActivity extends AppCompatActivity {
     private void fetchState() {
         motors = new HashMap<>();
         HubClient client = new HubClient("http://10.0.2.2:4310/");
-        client.getAllMotors(motors);
+//        client.getAllMotors(motors);
 //        testMotor(client);
 //        testSchedule(client);
 //        testLightSensors(client);
 //        testMotionSensors(client);
     }
-
-    private void testMotor(HubClient client) {
-        MotorSettingsRequest motorSettingsRequest = new MotorSettingsRequest(
-                "bedroom",
-                "1.2.3.4",
-                false,
-                0, 0, 0, "style");
-        // use Handler to force the actions to happen in order
-        Handler handler = new Handler();
-
-        postTime += DELAY;
-        handler.postDelayed(() -> client.getAllMotors(motors), postTime);
-
-        postTime += DELAY;
-        handler.postDelayed(() -> client.addMotor(motors, motorSettingsRequest), postTime);
-
-        // This is extremely bad
-        AtomicInteger id = new AtomicInteger(-1);
-
-        postTime += DELAY;
-        handler.postDelayed(() -> id.set(new ArrayList<>(motors.keySet()).get(0)), postTime);
-
-        postTime += DELAY;
-        handler.postDelayed(() -> client.activateMotor(motors, id.get()), postTime);
-
-        postTime += DELAY;
-        MotorSettingsRequest newMotorSettingsRequest = new MotorSettingsRequest("Mars", "5.6.7.8",
-                false, 0, 0, 0, "fancy");
-        handler.postDelayed(() -> client.updateMotor(motors, id.get(), newMotorSettingsRequest), postTime);
-
-        postTime += DELAY;
-        handler.postDelayed(() -> client.renameMotor(motors, id.get(), "kitchen"), postTime);
-
-        postTime += DELAY;
-        handler.postDelayed(() -> client.getMotor(motors, id.get()), postTime);
-
-        postTime += DELAY;
-        handler.postDelayed(() -> client.moveMotor(motors, id.get(), 25), postTime);
-
-        postTime += DELAY;
-        handler.postDelayed(() -> client.startMotorCalibration(motors, id.get()), postTime);
-
-        postTime += DELAY;
-        handler.postDelayed(() -> client.stopMotorCalibration(motors, id.get()), postTime);
-
-        postTime += DELAY;
-        handler.postDelayed(() -> client.deactivateMotor(motors, id.get()), postTime);
-
-        postTime += DELAY;
-        handler.postDelayed(() -> client.deleteMotor(motors, id.get()), postTime);
-    }
-
-    private void testSchedule(HubClient client) {
-        schedules = new HashMap<>();
-        List<Integer> motorIds = new ArrayList<>();
-        motorIds.add(999);
-        List<Day> days = new ArrayList<>();
-        days.add(Day.MONDAY);
-        ScheduleSettingsRequest scheduleSettingsRequest = new ScheduleSettingsRequest(
-                "name",
-                false,
-                days,
-                0, 0, motorIds, "16:20");
-
-        // use Handler to force the actions to happen in order
-        Handler handler = new Handler();
-
-        postTime += DELAY;
-        handler.postDelayed(() -> client.getAllSchedules(schedules), postTime);
-
-        postTime += DELAY;
-        handler.postDelayed(() -> client.addSchedule(schedules, scheduleSettingsRequest), postTime);
-
-        // This is extremely bad
-        postTime += DELAY;
-        AtomicInteger id = new AtomicInteger(-1);
-        handler.postDelayed(() -> id.set(new ArrayList<>(schedules.keySet()).get(0)), postTime);
-
-        postTime += DELAY;
-        ScheduleSettingsRequest newScheduleSettingsRequest = new ScheduleSettingsRequest(
-                "new name", false, days, 0, 12, motorIds, "00:00");
-        handler.postDelayed(() -> client.updateSchedule(schedules, id.get(), newScheduleSettingsRequest), postTime);
-
-        postTime += DELAY;
-        days.remove(0);
-        days.add(Day.SATURDAY);
-        days.add(Day.SUNDAY);
-        handler.postDelayed(() -> client.changeDaysSchedule(schedules, id.get(), days), postTime);
-
-        postTime += DELAY;
-        handler.postDelayed(() -> client.changeTimeSchedule(schedules, id.get(), "a"), postTime);
-
-        postTime += DELAY;
-        handler.postDelayed(() -> client.changeGradientSchedule(schedules, id.get(), 7216), postTime);
-
-        postTime += DELAY;
-        handler.postDelayed(() -> client.renameSchedule(schedules, id.get(), "newName"), postTime);
-
-        postTime += DELAY;
-        handler.postDelayed(() -> client.activateSchedule(schedules, id.get()), postTime);
-
-        postTime += DELAY;
-        handler.postDelayed(() -> client.deactivateSchedule(schedules, id.get()), postTime);
-
-        postTime += DELAY;
-        handler.postDelayed(() -> client.deleteSchedule(schedules, id.get()), postTime);
-    }
-
-    private void testLightSensors(HubClient client) {
-        lightSensors = new HashMap<>();
-        List<Integer> motorIds = new ArrayList<>();
-        motorIds.add(999);
-        LightSensorSettingsRequest lightSensorSettingsRequest = new LightSensorSettingsRequest(
-                motorIds, "name", "1.2.3.4", false, 0, "style");
-
-        // use Handler to force the actions to happen in order
-        Handler handler = new Handler();
-
-        postTime += DELAY;
-        handler.postDelayed(() -> client.getAllLightSensors(lightSensors), postTime);
-
-        postTime += DELAY;
-        handler.postDelayed(() -> client.addLightSensor(lightSensors, lightSensorSettingsRequest), postTime);
-
-        // This is extremely bad
-        postTime += DELAY;
-        AtomicInteger id = new AtomicInteger(-1);
-        handler.postDelayed(() -> id.set(new ArrayList<>(lightSensors.keySet()).get(0)), postTime);
-
-        postTime += DELAY;
-        LightSensorSettingsRequest newLightSensorSettingsRequest = new LightSensorSettingsRequest(
-                motorIds, "a", "0.0.0.0", false, 0, "style");
-        handler.postDelayed(() -> client.updateLightSensor(lightSensors, id.get(), newLightSensorSettingsRequest), postTime);
-
-        postTime += DELAY;
-        handler.postDelayed(() -> client.deleteLightSensor(lightSensors, id.get()), postTime);
-    }
-
-    private void testMotionSensors(HubClient client) {
-        motionSensors = new HashMap<>();
-        List<Integer> motorIds = new ArrayList<>();
-        motorIds.add(999);
-        MotionSensorSettingsRequest motionSensorSettingsRequest = new MotionSensorSettingsRequest(
-                motorIds, "name", "1.2.3.4", false, 0, "style", "30");
-
-        // use Handler to force the actions to happen in order
-        Handler handler = new Handler();
-
-        postTime += DELAY;
-        handler.postDelayed(() -> client.getAllMotionSensors(motionSensors), postTime);
-
-        postTime += DELAY;
-        handler.postDelayed(() -> client.addMotionSensor(motionSensors, motionSensorSettingsRequest), postTime);
-
-        // This is extremely bad
-        postTime += DELAY;
-        AtomicInteger id = new AtomicInteger(-1);
-        handler.postDelayed(() -> id.set(new ArrayList<>(motionSensors.keySet()).get(0)), postTime);
-
-        postTime += DELAY;
-        MotionSensorSettingsRequest newMotionSensorSettingsRequest = new MotionSensorSettingsRequest(
-                motorIds, "new", "1.1.1.1", false, 0, "style", "40");
-        handler.postDelayed(() -> client.updateMotionSensor(motionSensors, id.get(), newMotionSensorSettingsRequest), postTime);
-
-        postTime += DELAY;
-        handler.postDelayed(() -> client.deleteMotionSensor(motionSensors, id.get()), postTime);
-    }
+//
+//    private void testMotor(HubClient client) {
+//        MotorSettingsRequest motorSettingsRequest = new MotorSettingsRequest(
+//                "bedroom",
+//                "1.2.3.4",
+//                false,
+//                0, 0, 0, "style");
+//        // use Handler to force the actions to happen in order
+//        Handler handler = new Handler();
+//
+//        postTime += DELAY;
+//        handler.postDelayed(() -> client.getAllMotors(motors), postTime);
+//
+//        postTime += DELAY;
+//        handler.postDelayed(() -> client.addMotor(motors, motorSettingsRequest), postTime);
+//
+//        // This is extremely bad
+//        AtomicInteger id = new AtomicInteger(-1);
+//
+//        postTime += DELAY;
+//        handler.postDelayed(() -> id.set(new ArrayList<>(motors.keySet()).get(0)), postTime);
+//
+//        postTime += DELAY;
+//        handler.postDelayed(() -> client.activateMotor(motors, id.get()), postTime);
+//
+//        postTime += DELAY;
+//        MotorSettingsRequest newMotorSettingsRequest = new MotorSettingsRequest("Mars", "5.6.7.8",
+//                false, 0, 0, 0, "fancy");
+//        handler.postDelayed(() -> client.updateMotor(motors, id.get(), newMotorSettingsRequest), postTime);
+//
+//        postTime += DELAY;
+//        handler.postDelayed(() -> client.renameMotor(motors, id.get(), "kitchen"), postTime);
+//
+//        postTime += DELAY;
+//        handler.postDelayed(() -> client.getMotor(motors, id.get()), postTime);
+//
+//        postTime += DELAY;
+//        handler.postDelayed(() -> client.moveMotor(motors, id.get(), 25), postTime);
+//
+//        postTime += DELAY;
+//        handler.postDelayed(() -> client.startMotorCalibration(motors, id.get()), postTime);
+//
+//        postTime += DELAY;
+//        handler.postDelayed(() -> client.stopMotorCalibration(motors, id.get()), postTime);
+//
+//        postTime += DELAY;
+//        handler.postDelayed(() -> client.deactivateMotor(motors, id.get()), postTime);
+//
+//        postTime += DELAY;
+//        handler.postDelayed(() -> client.deleteMotor(motors, id.get()), postTime);
+//    }
+//
+//    private void testSchedule(HubClient client) {
+//        schedules = new HashMap<>();
+//        List<Integer> motorIds = new ArrayList<>();
+//        motorIds.add(999);
+//        List<Day> days = new ArrayList<>();
+//        days.add(Day.MONDAY);
+//        ScheduleSettingsRequest scheduleSettingsRequest = new ScheduleSettingsRequest(
+//                "name",
+//                false,
+//                days,
+//                0, 0, motorIds, "16:20");
+//
+//        // use Handler to force the actions to happen in order
+//        Handler handler = new Handler();
+//
+//        postTime += DELAY;
+//        handler.postDelayed(() -> client.getAllSchedules(schedules), postTime);
+//
+//        postTime += DELAY;
+//        handler.postDelayed(() -> client.addSchedule(schedules, scheduleSettingsRequest), postTime);
+//
+//        // This is extremely bad
+//        postTime += DELAY;
+//        AtomicInteger id = new AtomicInteger(-1);
+//        handler.postDelayed(() -> id.set(new ArrayList<>(schedules.keySet()).get(0)), postTime);
+//
+//        postTime += DELAY;
+//        ScheduleSettingsRequest newScheduleSettingsRequest = new ScheduleSettingsRequest(
+//                "new name", false, days, 0, 12, motorIds, "00:00");
+//        handler.postDelayed(() -> client.updateSchedule(schedules, id.get(), newScheduleSettingsRequest), postTime);
+//
+//        postTime += DELAY;
+//        days.remove(0);
+//        days.add(Day.SATURDAY);
+//        days.add(Day.SUNDAY);
+//        handler.postDelayed(() -> client.changeDaysSchedule(schedules, id.get(), days), postTime);
+//
+//        postTime += DELAY;
+//        handler.postDelayed(() -> client.changeTimeSchedule(schedules, id.get(), "a"), postTime);
+//
+//        postTime += DELAY;
+//        handler.postDelayed(() -> client.changeGradientSchedule(schedules, id.get(), 7216), postTime);
+//
+//        postTime += DELAY;
+//        handler.postDelayed(() -> client.renameSchedule(schedules, id.get(), "newName"), postTime);
+//
+//        postTime += DELAY;
+//        handler.postDelayed(() -> client.activateSchedule(schedules, id.get()), postTime);
+//
+//        postTime += DELAY;
+//        handler.postDelayed(() -> client.deactivateSchedule(schedules, id.get()), postTime);
+//
+//        postTime += DELAY;
+//        handler.postDelayed(() -> client.deleteSchedule(schedules, id.get()), postTime);
+//    }
+//
+//    private void testLightSensors(HubClient client) {
+//        lightSensors = new HashMap<>();
+//        List<Integer> motorIds = new ArrayList<>();
+//        motorIds.add(999);
+//        LightSensorSettingsRequest lightSensorSettingsRequest = new LightSensorSettingsRequest(
+//                motorIds, "name", "1.2.3.4", false, 0, "style");
+//
+//        // use Handler to force the actions to happen in order
+//        Handler handler = new Handler();
+//
+//        postTime += DELAY;
+//        handler.postDelayed(() -> client.getAllLightSensors(lightSensors), postTime);
+//
+//        postTime += DELAY;
+//        handler.postDelayed(() -> client.addLightSensor(lightSensors, lightSensorSettingsRequest), postTime);
+//
+//        // This is extremely bad
+//        postTime += DELAY;
+//        AtomicInteger id = new AtomicInteger(-1);
+//        handler.postDelayed(() -> id.set(new ArrayList<>(lightSensors.keySet()).get(0)), postTime);
+//
+//        postTime += DELAY;
+//        LightSensorSettingsRequest newLightSensorSettingsRequest = new LightSensorSettingsRequest(
+//                motorIds, "a", "0.0.0.0", false, 0, "style");
+//        handler.postDelayed(() -> client.updateLightSensor(lightSensors, id.get(), newLightSensorSettingsRequest), postTime);
+//
+//        postTime += DELAY;
+//        handler.postDelayed(() -> client.deleteLightSensor(lightSensors, id.get()), postTime);
+//    }
+//
+//    private void testMotionSensors(HubClient client) {
+//        motionSensors = new HashMap<>();
+//        List<Integer> motorIds = new ArrayList<>();
+//        motorIds.add(999);
+//        MotionSensorSettingsRequest motionSensorSettingsRequest = new MotionSensorSettingsRequest(
+//                motorIds, "name", "1.2.3.4", false, 0, "style", "30");
+//
+//        // use Handler to force the actions to happen in order
+//        Handler handler = new Handler();
+//
+//        postTime += DELAY;
+//        handler.postDelayed(() -> client.getAllMotionSensors(motionSensors), postTime);
+//
+//        postTime += DELAY;
+//        handler.postDelayed(() -> client.addMotionSensor(motionSensors, motionSensorSettingsRequest), postTime);
+//
+//        // This is extremely bad
+//        postTime += DELAY;
+//        AtomicInteger id = new AtomicInteger(-1);
+//        handler.postDelayed(() -> id.set(new ArrayList<>(motionSensors.keySet()).get(0)), postTime);
+//
+//        postTime += DELAY;
+//        MotionSensorSettingsRequest newMotionSensorSettingsRequest = new MotionSensorSettingsRequest(
+//                motorIds, "new", "1.1.1.1", false, 0, "style", "40");
+//        handler.postDelayed(() -> client.updateMotionSensor(motionSensors, id.get(), newMotionSensorSettingsRequest), postTime);
+//
+//        postTime += DELAY;
+//        handler.postDelayed(() -> client.deleteMotionSensor(motionSensors, id.get()), postTime);
+//    }
 }

--- a/app/src/main/java/com/helio/app/MainActivity.java
+++ b/app/src/main/java/com/helio/app/MainActivity.java
@@ -1,7 +1,6 @@
 package com.helio.app;
 
 import android.os.Bundle;
-import android.os.Handler;
 import android.view.MenuItem;
 
 import androidx.annotation.NonNull;
@@ -12,30 +11,8 @@ import androidx.navigation.ui.AppBarConfiguration;
 import androidx.navigation.ui.NavigationUI;
 
 import com.google.android.material.bottomnavigation.BottomNavigationView;
-import com.helio.app.model.Day;
-import com.helio.app.model.LightSensor;
-import com.helio.app.model.MotionSensor;
-import com.helio.app.model.Motor;
-import com.helio.app.model.Schedule;
-import com.helio.app.networking.HubClient;
-import com.helio.app.networking.request.LightSensorSettingsRequest;
-import com.helio.app.networking.request.MotionSensorSettingsRequest;
-import com.helio.app.networking.request.MotorSettingsRequest;
-import com.helio.app.networking.request.ScheduleSettingsRequest;
-
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
 
 public class MainActivity extends AppCompatActivity {
-    public static final int DELAY = 500;
-    private int postTime = 0;
-    private Map<Integer, Motor> motors;
-    private Map<Integer, Schedule> schedules;
-    private Map<Integer, LightSensor> lightSensors;
-    private Map<Integer, MotionSensor> motionSensors;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -55,8 +32,6 @@ public class MainActivity extends AppCompatActivity {
         // This makes the fragment change when you press the navigation buttons
         BottomNavigationView navView = findViewById(R.id.nav_view);
         NavigationUI.setupWithNavController(navView, navController);
-
-        fetchState();
     }
 
     @Override
@@ -67,181 +42,4 @@ public class MainActivity extends AppCompatActivity {
         }
         return super.onOptionsItemSelected(item);
     }
-
-    private void fetchState() {
-        motors = new HashMap<>();
-        HubClient client = new HubClient("http://10.0.2.2:4310/");
-//        client.getAllMotors(motors);
-//        testMotor(client);
-//        testSchedule(client);
-//        testLightSensors(client);
-//        testMotionSensors(client);
-    }
-//
-//    private void testMotor(HubClient client) {
-//        MotorSettingsRequest motorSettingsRequest = new MotorSettingsRequest(
-//                "bedroom",
-//                "1.2.3.4",
-//                false,
-//                0, 0, 0, "style");
-//        // use Handler to force the actions to happen in order
-//        Handler handler = new Handler();
-//
-//        postTime += DELAY;
-//        handler.postDelayed(() -> client.getAllMotors(motors), postTime);
-//
-//        postTime += DELAY;
-//        handler.postDelayed(() -> client.addMotor(motors, motorSettingsRequest), postTime);
-//
-//        // This is extremely bad
-//        AtomicInteger id = new AtomicInteger(-1);
-//
-//        postTime += DELAY;
-//        handler.postDelayed(() -> id.set(new ArrayList<>(motors.keySet()).get(0)), postTime);
-//
-//        postTime += DELAY;
-//        handler.postDelayed(() -> client.activateMotor(motors, id.get()), postTime);
-//
-//        postTime += DELAY;
-//        MotorSettingsRequest newMotorSettingsRequest = new MotorSettingsRequest("Mars", "5.6.7.8",
-//                false, 0, 0, 0, "fancy");
-//        handler.postDelayed(() -> client.updateMotor(motors, id.get(), newMotorSettingsRequest), postTime);
-//
-//        postTime += DELAY;
-//        handler.postDelayed(() -> client.renameMotor(motors, id.get(), "kitchen"), postTime);
-//
-//        postTime += DELAY;
-//        handler.postDelayed(() -> client.getMotor(motors, id.get()), postTime);
-//
-//        postTime += DELAY;
-//        handler.postDelayed(() -> client.moveMotor(motors, id.get(), 25), postTime);
-//
-//        postTime += DELAY;
-//        handler.postDelayed(() -> client.startMotorCalibration(motors, id.get()), postTime);
-//
-//        postTime += DELAY;
-//        handler.postDelayed(() -> client.stopMotorCalibration(motors, id.get()), postTime);
-//
-//        postTime += DELAY;
-//        handler.postDelayed(() -> client.deactivateMotor(motors, id.get()), postTime);
-//
-//        postTime += DELAY;
-//        handler.postDelayed(() -> client.deleteMotor(motors, id.get()), postTime);
-//    }
-//
-//    private void testSchedule(HubClient client) {
-//        schedules = new HashMap<>();
-//        List<Integer> motorIds = new ArrayList<>();
-//        motorIds.add(999);
-//        List<Day> days = new ArrayList<>();
-//        days.add(Day.MONDAY);
-//        ScheduleSettingsRequest scheduleSettingsRequest = new ScheduleSettingsRequest(
-//                "name",
-//                false,
-//                days,
-//                0, 0, motorIds, "16:20");
-//
-//        // use Handler to force the actions to happen in order
-//        Handler handler = new Handler();
-//
-//        postTime += DELAY;
-//        handler.postDelayed(() -> client.getAllSchedules(schedules), postTime);
-//
-//        postTime += DELAY;
-//        handler.postDelayed(() -> client.addSchedule(schedules, scheduleSettingsRequest), postTime);
-//
-//        // This is extremely bad
-//        postTime += DELAY;
-//        AtomicInteger id = new AtomicInteger(-1);
-//        handler.postDelayed(() -> id.set(new ArrayList<>(schedules.keySet()).get(0)), postTime);
-//
-//        postTime += DELAY;
-//        ScheduleSettingsRequest newScheduleSettingsRequest = new ScheduleSettingsRequest(
-//                "new name", false, days, 0, 12, motorIds, "00:00");
-//        handler.postDelayed(() -> client.updateSchedule(schedules, id.get(), newScheduleSettingsRequest), postTime);
-//
-//        postTime += DELAY;
-//        days.remove(0);
-//        days.add(Day.SATURDAY);
-//        days.add(Day.SUNDAY);
-//        handler.postDelayed(() -> client.changeDaysSchedule(schedules, id.get(), days), postTime);
-//
-//        postTime += DELAY;
-//        handler.postDelayed(() -> client.changeTimeSchedule(schedules, id.get(), "a"), postTime);
-//
-//        postTime += DELAY;
-//        handler.postDelayed(() -> client.changeGradientSchedule(schedules, id.get(), 7216), postTime);
-//
-//        postTime += DELAY;
-//        handler.postDelayed(() -> client.renameSchedule(schedules, id.get(), "newName"), postTime);
-//
-//        postTime += DELAY;
-//        handler.postDelayed(() -> client.activateSchedule(schedules, id.get()), postTime);
-//
-//        postTime += DELAY;
-//        handler.postDelayed(() -> client.deactivateSchedule(schedules, id.get()), postTime);
-//
-//        postTime += DELAY;
-//        handler.postDelayed(() -> client.deleteSchedule(schedules, id.get()), postTime);
-//    }
-//
-//    private void testLightSensors(HubClient client) {
-//        lightSensors = new HashMap<>();
-//        List<Integer> motorIds = new ArrayList<>();
-//        motorIds.add(999);
-//        LightSensorSettingsRequest lightSensorSettingsRequest = new LightSensorSettingsRequest(
-//                motorIds, "name", "1.2.3.4", false, 0, "style");
-//
-//        // use Handler to force the actions to happen in order
-//        Handler handler = new Handler();
-//
-//        postTime += DELAY;
-//        handler.postDelayed(() -> client.getAllLightSensors(lightSensors), postTime);
-//
-//        postTime += DELAY;
-//        handler.postDelayed(() -> client.addLightSensor(lightSensors, lightSensorSettingsRequest), postTime);
-//
-//        // This is extremely bad
-//        postTime += DELAY;
-//        AtomicInteger id = new AtomicInteger(-1);
-//        handler.postDelayed(() -> id.set(new ArrayList<>(lightSensors.keySet()).get(0)), postTime);
-//
-//        postTime += DELAY;
-//        LightSensorSettingsRequest newLightSensorSettingsRequest = new LightSensorSettingsRequest(
-//                motorIds, "a", "0.0.0.0", false, 0, "style");
-//        handler.postDelayed(() -> client.updateLightSensor(lightSensors, id.get(), newLightSensorSettingsRequest), postTime);
-//
-//        postTime += DELAY;
-//        handler.postDelayed(() -> client.deleteLightSensor(lightSensors, id.get()), postTime);
-//    }
-//
-//    private void testMotionSensors(HubClient client) {
-//        motionSensors = new HashMap<>();
-//        List<Integer> motorIds = new ArrayList<>();
-//        motorIds.add(999);
-//        MotionSensorSettingsRequest motionSensorSettingsRequest = new MotionSensorSettingsRequest(
-//                motorIds, "name", "1.2.3.4", false, 0, "style", "30");
-//
-//        // use Handler to force the actions to happen in order
-//        Handler handler = new Handler();
-//
-//        postTime += DELAY;
-//        handler.postDelayed(() -> client.getAllMotionSensors(motionSensors), postTime);
-//
-//        postTime += DELAY;
-//        handler.postDelayed(() -> client.addMotionSensor(motionSensors, motionSensorSettingsRequest), postTime);
-//
-//        // This is extremely bad
-//        postTime += DELAY;
-//        AtomicInteger id = new AtomicInteger(-1);
-//        handler.postDelayed(() -> id.set(new ArrayList<>(motionSensors.keySet()).get(0)), postTime);
-//
-//        postTime += DELAY;
-//        MotionSensorSettingsRequest newMotionSensorSettingsRequest = new MotionSensorSettingsRequest(
-//                motorIds, "new", "1.1.1.1", false, 0, "style", "40");
-//        handler.postDelayed(() -> client.updateMotionSensor(motionSensors, id.get(), newMotionSensorSettingsRequest), postTime);
-//
-//        postTime += DELAY;
-//        handler.postDelayed(() -> client.deleteMotionSensor(motionSensors, id.get()), postTime);
-//    }
 }

--- a/app/src/main/java/com/helio/app/MainActivity.java
+++ b/app/src/main/java/com/helio/app/MainActivity.java
@@ -71,10 +71,11 @@ public class MainActivity extends AppCompatActivity {
     private void fetchState() {
         motors = new HashMap<>();
         HubClient client = new HubClient("http://10.0.2.2:4310/");
-        testMotor(client);
-        testSchedule(client);
-        testLightSensors(client);
-        testMotionSensors(client);
+        client.getAllMotors(motors);
+//        testMotor(client);
+//        testSchedule(client);
+//        testLightSensors(client);
+//        testMotionSensors(client);
     }
 
     private void testMotor(HubClient client) {

--- a/app/src/main/java/com/helio/app/UserDataViewModel.java
+++ b/app/src/main/java/com/helio/app/UserDataViewModel.java
@@ -1,0 +1,23 @@
+package com.helio.app;
+
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.MutableLiveData;
+import androidx.lifecycle.ViewModel;
+
+import com.helio.app.model.Motor;
+import com.helio.app.networking.HubClient;
+
+import java.util.Map;
+
+public class UserDataViewModel extends ViewModel {
+    private final HubClient client = new HubClient("http://10.0.2.2:4310/");
+    private MutableLiveData<Map<Integer, Motor>> motors;
+
+    public LiveData<Map<Integer, Motor>> fetchMotors() {
+        if(motors == null) {
+            motors = new MutableLiveData<>();
+            client.getAllMotors(motors);
+        }
+        return motors;
+    }
+}

--- a/app/src/main/java/com/helio/app/UserDataViewModel.java
+++ b/app/src/main/java/com/helio/app/UserDataViewModel.java
@@ -6,8 +6,10 @@ import androidx.lifecycle.ViewModel;
 
 import com.helio.app.model.Motor;
 import com.helio.app.networking.HubClient;
+import com.helio.app.networking.request.MotorSettingsRequest;
 
 import java.util.Map;
+import java.util.Objects;
 
 public class UserDataViewModel extends ViewModel {
     private final HubClient client = new HubClient("http://10.0.2.2:4310/");
@@ -31,6 +33,15 @@ public class UserDataViewModel extends ViewModel {
     }
 
     public Motor getCurrentMotor() {
-        return motors.getValue().get(currentMotorId);
+        return Objects.requireNonNull(motors.getValue()).get(currentMotorId);
+    }
+
+    public void pushCurrentMotorState(Motor m) {
+        motors.getValue().put(currentMotorId, m);
+        MotorSettingsRequest motorSettingsRequest = new MotorSettingsRequest(
+                m.getName(), m.getIp(), m.isActive(), m.getBattery(), m.getLength(),
+                m.getLevel(), m.getStyle()
+        );
+        client.updateMotor(motors.getValue(), currentMotorId, motorSettingsRequest);
     }
 }

--- a/app/src/main/java/com/helio/app/UserDataViewModel.java
+++ b/app/src/main/java/com/helio/app/UserDataViewModel.java
@@ -12,6 +12,7 @@ import java.util.Map;
 public class UserDataViewModel extends ViewModel {
     private final HubClient client = new HubClient("http://10.0.2.2:4310/");
     private MutableLiveData<Map<Integer, Motor>> motors;
+    private int currentMotorId = -1;
 
     public LiveData<Map<Integer, Motor>> fetchMotors() {
         if(motors == null) {
@@ -19,5 +20,17 @@ public class UserDataViewModel extends ViewModel {
             client.getAllMotors(motors);
         }
         return motors;
+    }
+
+    public void setCurrentMotor(int id) {
+        currentMotorId = id;
+    }
+
+    public void moveCurrentMotor(int level) {
+        client.moveMotor(getCurrentMotor(), level);
+    }
+
+    public Motor getCurrentMotor() {
+        return motors.getValue().get(currentMotorId);
     }
 }

--- a/app/src/main/java/com/helio/app/networking/GetAllCallback.java
+++ b/app/src/main/java/com/helio/app/networking/GetAllCallback.java
@@ -1,9 +1,12 @@
 package com.helio.app.networking;
 
+import androidx.lifecycle.MutableLiveData;
+
 import com.helio.app.model.IdComponent;
 
 import org.jetbrains.annotations.NotNull;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -12,9 +15,9 @@ import retrofit2.Callback;
 import retrofit2.Response;
 
 public class GetAllCallback<T extends IdComponent> implements Callback<List<T>> {
-    private final Map<Integer, T> map;
+    private final MutableLiveData<Map<Integer, T>> map;
 
-    public GetAllCallback(Map<Integer, T> map) {
+    public GetAllCallback(MutableLiveData<Map<Integer, T>> map) {
         this.map = map;
     }
 
@@ -24,10 +27,11 @@ public class GetAllCallback<T extends IdComponent> implements Callback<List<T>> 
         if (responseList != null) {
             System.out.println(call + " succeeded: " + responseList);
             // Clear the map and replace with the new one
-            map.clear();
+            Map<Integer, T> resultsMap = new HashMap<>();
             for (T t : responseList) {
-                map.put(t.getId(), t);
+                resultsMap.put(t.getId(), t);
             }
+            map.setValue(resultsMap);
             System.out.println("Updated local state for " + responseList);
         } else {
             System.out.println("Communication error");

--- a/app/src/main/java/com/helio/app/networking/HubClient.java
+++ b/app/src/main/java/com/helio/app/networking/HubClient.java
@@ -1,5 +1,7 @@
 package com.helio.app.networking;
 
+import androidx.lifecycle.MutableLiveData;
+
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.helio.app.model.Day;
@@ -110,12 +112,12 @@ public class HubClient {
         call.enqueue(new DeletionCallback<>(motors, motorId));
     }
 
-    public void getAllMotors(Map<Integer, Motor> motors) {
+    public void getAllMotors(MutableLiveData<Map<Integer, Motor>> motors) {
         Call<List<Motor>> call = service.getAllMotors();
         call.enqueue(new GetAllCallback<>(motors));
     }
 
-    public void getAllSchedules(Map<Integer, Schedule> schedules) {
+    public void getAllSchedules(MutableLiveData<Map<Integer, Schedule>> schedules) {
         Call<List<Schedule>> call = service.getAllSchedules();
         call.enqueue(new GetAllCallback<>(schedules));
     }
@@ -165,7 +167,7 @@ public class HubClient {
         call.enqueue(new IdComponentCallback<>(schedules));
     }
 
-    public void getAllLightSensors(Map<Integer, LightSensor> sensors) {
+    public void getAllLightSensors(MutableLiveData<Map<Integer, LightSensor>> sensors) {
         Call<List<LightSensor>> call = service.getAllLightSensors();
         call.enqueue(new GetAllCallback<>(sensors));
     }
@@ -185,7 +187,7 @@ public class HubClient {
         call.enqueue(new IdComponentCallback<>(sensors));
     }
 
-    public void getAllMotionSensors(Map<Integer, MotionSensor> sensors) {
+    public void getAllMotionSensors(MutableLiveData<Map<Integer, MotionSensor>> sensors) {
         Call<List<MotionSensor>> call = service.getAllMotionSensors();
         call.enqueue(new GetAllCallback<>(sensors));
     }

--- a/app/src/main/java/com/helio/app/networking/HubClient.java
+++ b/app/src/main/java/com/helio/app/networking/HubClient.java
@@ -92,9 +92,9 @@ public class HubClient {
         call.enqueue(new IdComponentCallback<>(motors));
     }
 
-    public void moveMotor(Map<Integer, Motor> motors, int id, int level) {
-        Call<Motor> call = service.moveMotor(id, level);
-        call.enqueue(new IdComponentCallback<>(motors));
+    public void moveMotor(Motor motor, int level) {
+        Call<Motor> call = service.moveMotor(motor.getId(), level);
+        call.enqueue(new MoveMotorCallback());
     }
 
     public void startMotorCalibration(Map<Integer, Motor> motors, int motorId) {

--- a/app/src/main/java/com/helio/app/networking/MoveMotorCallback.java
+++ b/app/src/main/java/com/helio/app/networking/MoveMotorCallback.java
@@ -1,0 +1,27 @@
+package com.helio.app.networking;
+
+import com.helio.app.model.Motor;
+
+import org.jetbrains.annotations.NotNull;
+
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
+
+public class MoveMotorCallback implements Callback<Motor> {
+
+    @Override
+    public void onResponse(@NotNull Call<Motor> call, Response<Motor> response) {
+        Motor motor = response.body();
+        if (motor != null) {
+            System.out.println(call + " succeeded: " + motor);
+        } else {
+            System.out.println("Communication error");
+        }
+    }
+
+    @Override
+    public void onFailure(@NotNull Call<Motor> call, @NotNull Throwable t) {
+        System.out.println(call + " failed: " + t);
+    }
+}

--- a/app/src/main/java/com/helio/app/ui/blind/SingleBlindSettingsFragment.java
+++ b/app/src/main/java/com/helio/app/ui/blind/SingleBlindSettingsFragment.java
@@ -8,10 +8,14 @@ import android.view.ViewGroup;
 import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
 import androidx.lifecycle.ViewModelProvider;
+import androidx.preference.EditTextPreference;
+import androidx.preference.ListPreference;
+import androidx.preference.Preference;
 
 import com.helio.app.R;
 import com.helio.app.UserDataViewModel;
 import com.helio.app.model.Motor;
+import com.helio.app.ui.MotorIcon;
 
 public class SingleBlindSettingsFragment extends Fragment {
 
@@ -34,7 +38,7 @@ public class SingleBlindSettingsFragment extends Fragment {
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater,
                              ViewGroup container, Bundle savedInstanceState) {
-        View returnView = inflater.inflate(R.layout.fragment_single_blind_settings, container, false);
+        View view = inflater.inflate(R.layout.fragment_single_blind_settings, container, false);
         assert getArguments() != null;
         int motorId = getArguments().getInt("currentMotorId");
 
@@ -44,10 +48,48 @@ public class SingleBlindSettingsFragment extends Fragment {
                 getViewLifecycleOwner(),
                 motors -> {
                     motor = motors.get(motorId);
+                    SingleBlindSettingsPreferencesFragment preferenceFragment = (SingleBlindSettingsPreferencesFragment)
+                            getChildFragmentManager().findFragmentById(R.id.fragment_container_preferences);
+
+                    EditTextPreference namePreference = preferenceFragment.findPreference("name");
+                    EditTextPreference ipPreference = preferenceFragment.findPreference("ip");
+                    ListPreference iconPreference = preferenceFragment.findPreference("icon");
+
+                    namePreference.setText(motor.getName());
+                    ipPreference.setText(motor.getIp());
+
+                    if (motor.getIcon() == null) {
+                        // If motor has no icon then set to None
+                        iconPreference.setValueIndex(iconPreference.getEntryValues().length - 1);
+                    } else {
+                        iconPreference.setValue(motor.getIcon().name);
+                    }
+
+                    namePreference.setOnPreferenceChangeListener((preference, newValue) -> {
+                        motor.setName((String) newValue);
+                        return true;
+                    });
+                    ipPreference.setOnPreferenceChangeListener(((preference, newValue) -> {
+                        motor.setIp((String) newValue);
+                        return true;
+                    }));
+                    iconPreference.setOnPreferenceChangeListener((preference, newValue) -> {
+                        motor.setStyle((String) newValue);
+                        return true;
+                    });
                 }
         );
-        setActionListeners(returnView);
-        return returnView;
+        setActionListeners(view);
+        return view;
     }
 
+    @Override
+    public void onStop() {
+        // Send changes to the motor state when the settings are closed
+        // Check if null in case something is wrong or it hasn't loaded in yet
+        if (motor != null) {
+            model.pushCurrentMotorState(motor);
+        }
+        super.onStop();
+    }
 }

--- a/app/src/main/java/com/helio/app/ui/blind/SingleBlindSettingsFragment.java
+++ b/app/src/main/java/com/helio/app/ui/blind/SingleBlindSettingsFragment.java
@@ -21,9 +21,15 @@ public class SingleBlindSettingsFragment extends Fragment {
     private UserDataViewModel model;
 
     private void setActionListeners(View view) {
+        // "open" button
         view.findViewById(R.id.btn_open).setOnClickListener(v -> {
-            System.out.println("OPEN BUTTON PRESSED FOR " + model.getCurrentMotor());
+            System.out.println("OPEN button pressed for " + model.getCurrentMotor());
             model.moveCurrentMotor(0);
+        });
+        // "close" button
+        view.findViewById(R.id.btn_close).setOnClickListener(v -> {
+            System.out.println("CLOSE button pressed for " + model.getCurrentMotor());
+            model.moveCurrentMotor(100);
         });
     }
 

--- a/app/src/main/java/com/helio/app/ui/blind/SingleBlindSettingsFragment.java
+++ b/app/src/main/java/com/helio/app/ui/blind/SingleBlindSettingsFragment.java
@@ -13,8 +13,6 @@ import com.helio.app.R;
 import com.helio.app.UserDataViewModel;
 import com.helio.app.model.Motor;
 
-import java.util.ArrayList;
-
 public class SingleBlindSettingsFragment extends Fragment {
 
     private Motor motor;

--- a/app/src/main/java/com/helio/app/ui/blind/SingleBlindSettingsFragment.java
+++ b/app/src/main/java/com/helio/app/ui/blind/SingleBlindSettingsFragment.java
@@ -16,6 +16,8 @@ public class SingleBlindSettingsFragment extends Fragment {
     public View onCreateView(@NonNull LayoutInflater inflater,
                              ViewGroup container, Bundle savedInstanceState) {
         View returnView = inflater.inflate(R.layout.fragment_single_blind_settings, container, false);
+        assert getArguments() != null;
+        int motorId = getArguments().getInt("currentMotorId");
 
         return returnView;
     }

--- a/app/src/main/java/com/helio/app/ui/blind/SingleBlindSettingsFragment.java
+++ b/app/src/main/java/com/helio/app/ui/blind/SingleBlindSettingsFragment.java
@@ -22,12 +22,12 @@ public class SingleBlindSettingsFragment extends Fragment {
         // "open" button
         view.findViewById(R.id.btn_open).setOnClickListener(v -> {
             System.out.println("OPEN button pressed for " + model.getCurrentMotor());
-            model.moveCurrentMotor(0);
+            model.moveCurrentMotor(100);
         });
         // "close" button
         view.findViewById(R.id.btn_close).setOnClickListener(v -> {
             System.out.println("CLOSE button pressed for " + model.getCurrentMotor());
-            model.moveCurrentMotor(100);
+            model.moveCurrentMotor(0);
         });
     }
 

--- a/app/src/main/java/com/helio/app/ui/blind/SingleBlindSettingsFragment.java
+++ b/app/src/main/java/com/helio/app/ui/blind/SingleBlindSettingsFragment.java
@@ -7,10 +7,25 @@ import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
+import androidx.lifecycle.ViewModelProvider;
 
 import com.helio.app.R;
+import com.helio.app.UserDataViewModel;
+import com.helio.app.model.Motor;
+
+import java.util.ArrayList;
 
 public class SingleBlindSettingsFragment extends Fragment {
+
+    private Motor motor;
+    private UserDataViewModel model;
+
+    private void setActionListeners(View view) {
+        view.findViewById(R.id.btn_open).setOnClickListener(v -> {
+            System.out.println("OPEN BUTTON PRESSED FOR " + model.getCurrentMotor());
+            model.moveCurrentMotor(0);
+        });
+    }
 
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater,
@@ -19,6 +34,15 @@ public class SingleBlindSettingsFragment extends Fragment {
         assert getArguments() != null;
         int motorId = getArguments().getInt("currentMotorId");
 
+        model = new ViewModelProvider(requireActivity()).get(UserDataViewModel.class);
+        model.setCurrentMotor(motorId);
+        model.fetchMotors().observe(
+                getViewLifecycleOwner(),
+                motors -> {
+                    motor = motors.get(motorId);
+                }
+        );
+        setActionListeners(returnView);
         return returnView;
     }
 

--- a/app/src/main/java/com/helio/app/ui/blind/SingleBlindSettingsPreferencesFragment.java
+++ b/app/src/main/java/com/helio/app/ui/blind/SingleBlindSettingsPreferencesFragment.java
@@ -19,10 +19,8 @@ public class SingleBlindSettingsPreferencesFragment extends PreferenceFragmentCo
 
         EditTextPreference namePreference = findPreference("name");
         EditTextPreference ipPreference = findPreference("ip");
-        ListPreference changeIconPreference = findPreference("changeIcon");
+        ListPreference iconPreference = findPreference("icon");
         Preference calibrationPreference = findPreference("calibration");
-        Preference openNowPreference = findPreference("openNow");
-        Preference closeNowPreference = findPreference("closeNow");
         Preference createSchedulePreference = findPreference("createSchedule");
         Preference seeSchedulePreference = findPreference("seeSchedule");
         Preference motionSensorPreference = findPreference("motionSensor");

--- a/app/src/main/java/com/helio/app/ui/blinds/BlindsRecViewAdapter.java
+++ b/app/src/main/java/com/helio/app/ui/blinds/BlindsRecViewAdapter.java
@@ -15,6 +15,7 @@ import androidx.recyclerview.widget.RecyclerView;
 
 import com.helio.app.R;
 import com.helio.app.model.Motor;
+import com.helio.app.ui.MotorIcon;
 
 import java.util.ArrayList;
 
@@ -39,7 +40,10 @@ public class BlindsRecViewAdapter extends RecyclerView.Adapter<BlindsRecViewAdap
     @Override
     public void onBindViewHolder(@NonNull ViewHolder holder, int position) {
         holder.txtName.setText(motors.get(position).getName());
-        holder.blindIcon.setImageResource(motors.get(position).getIcon().id);
+        MotorIcon icon = motors.get(position).getIcon();
+        if(icon != null) {
+            holder.blindIcon.setImageResource(icon.id);
+        }
         holder.parent.setOnClickListener(v ->
         {
             Toast.makeText(context, motors.get(position).getName() + " Selected",

--- a/app/src/main/java/com/helio/app/ui/blinds/BlindsRecViewAdapter.java
+++ b/app/src/main/java/com/helio/app/ui/blinds/BlindsRecViewAdapter.java
@@ -27,9 +27,9 @@ public class BlindsRecViewAdapter extends RecyclerView.Adapter<BlindsRecViewAdap
     private final UserDataViewModel model;
     private ArrayList<Motor> motors = new ArrayList<>();
 
-    public BlindsRecViewAdapter(Context context, BlindsSettingsFragment fragment) {
+    public BlindsRecViewAdapter(Context context, UserDataViewModel model) {
         this.context = context;
-        this.model = new ViewModelProvider(fragment).get(UserDataViewModel.class);
+        this.model = model;
     }
 
     @NonNull

--- a/app/src/main/java/com/helio/app/ui/blinds/BlindsRecViewAdapter.java
+++ b/app/src/main/java/com/helio/app/ui/blinds/BlindsRecViewAdapter.java
@@ -10,10 +10,12 @@ import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.cardview.widget.CardView;
+import androidx.lifecycle.ViewModelProvider;
 import androidx.navigation.Navigation;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.helio.app.R;
+import com.helio.app.UserDataViewModel;
 import com.helio.app.model.Motor;
 import com.helio.app.ui.MotorIcon;
 
@@ -22,12 +24,13 @@ import java.util.ArrayList;
 public class BlindsRecViewAdapter extends RecyclerView.Adapter<BlindsRecViewAdapter.ViewHolder> {
 
     private final Context context;
+    private final UserDataViewModel model;
     private ArrayList<Motor> motors = new ArrayList<>();
 
-    public BlindsRecViewAdapter(Context context) {
+    public BlindsRecViewAdapter(Context context, BlindsSettingsFragment fragment) {
         this.context = context;
+        this.model = new ViewModelProvider(fragment).get(UserDataViewModel.class);
     }
-
 
     @NonNull
     @Override
@@ -39,8 +42,9 @@ public class BlindsRecViewAdapter extends RecyclerView.Adapter<BlindsRecViewAdap
 
     @Override
     public void onBindViewHolder(@NonNull ViewHolder holder, int position) {
-        holder.txtName.setText(motors.get(position).getName());
-        MotorIcon icon = motors.get(position).getIcon();
+        Motor motor = motors.get(position);
+        holder.txtName.setText(motor.getName());
+        MotorIcon icon = motor.getIcon();
         if(icon != null) {
             holder.blindIcon.setImageResource(icon.id);
         }

--- a/app/src/main/java/com/helio/app/ui/blinds/BlindsRecViewAdapter.java
+++ b/app/src/main/java/com/helio/app/ui/blinds/BlindsRecViewAdapter.java
@@ -31,7 +31,8 @@ public class BlindsRecViewAdapter extends RecyclerView.Adapter<BlindsRecViewAdap
     @NonNull
     @Override
     public ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
-        View view = LayoutInflater.from(parent.getContext()).inflate(R.layout.blinds_list_item, parent, false);
+        View view = LayoutInflater.from(parent.getContext()).inflate(R.layout.blinds_list_item,
+                parent, false);
         return new ViewHolder(view);
     }
 
@@ -41,8 +42,11 @@ public class BlindsRecViewAdapter extends RecyclerView.Adapter<BlindsRecViewAdap
         holder.blindIcon.setImageResource(motors.get(position).getIcon().id);
         holder.parent.setOnClickListener(v ->
         {
-            Toast.makeText(context, motors.get(position).getName() + " Selected", Toast.LENGTH_SHORT).show();
-            Navigation.findNavController(holder.itemView).navigate(R.id.action_blindsSettingsFragment_to_singleBlindSettingsFragment);
+            Toast.makeText(context, motors.get(position).getName() + " Selected",
+                    Toast.LENGTH_SHORT).show();
+            Navigation.findNavController(holder.itemView).navigate(
+                    R.id.action_blindsSettingsFragment_to_singleBlindSettingsFragment
+            );
         });
     }
 

--- a/app/src/main/java/com/helio/app/ui/blinds/BlindsRecViewAdapter.java
+++ b/app/src/main/java/com/helio/app/ui/blinds/BlindsRecViewAdapter.java
@@ -46,11 +46,17 @@ public class BlindsRecViewAdapter extends RecyclerView.Adapter<BlindsRecViewAdap
         }
         holder.parent.setOnClickListener(v ->
         {
-            Toast.makeText(context, motors.get(position).getName() + " Selected",
+            /*  The following line is horribly convoluted, but it follows the advice given here:
+                https://developer.android.com/guide/navigation/navigation-pass-data#define_destination_arguments
+                In short, this allows us to pass an argument (the id of the motor) to the single
+                blind settings fragment.
+             */
+            BlindsSettingsFragmentDirections.ActionBlindsSettingsFragmentToSingleBlindSettingsFragment action =
+                    BlindsSettingsFragmentDirections.actionBlindsSettingsFragmentToSingleBlindSettingsFragment();
+            action.setCurrentMotorId(motor.getId());
+            Toast.makeText(context, motor.getName() + " Selected",
                     Toast.LENGTH_SHORT).show();
-            Navigation.findNavController(holder.itemView).navigate(
-                    R.id.action_blindsSettingsFragment_to_singleBlindSettingsFragment
-            );
+            Navigation.findNavController(holder.itemView).navigate(action);
         });
     }
 

--- a/app/src/main/java/com/helio/app/ui/blinds/BlindsSettingsFragment.java
+++ b/app/src/main/java/com/helio/app/ui/blinds/BlindsSettingsFragment.java
@@ -21,7 +21,7 @@ public class BlindsSettingsFragment extends Fragment {
     public View onCreateView(@NonNull LayoutInflater inflater,
                              ViewGroup container, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.fragment_blinds_settings, container, false);
-        UserDataViewModel model = new ViewModelProvider(requireActivity()).get(UserDataViewModel.class);
+        UserDataViewModel model = new ViewModelProvider(this).get(UserDataViewModel.class);
         BlindsRecViewAdapter adapter = new BlindsRecViewAdapter(getContext(), model);
         model.fetchMotors().observe(
                 getViewLifecycleOwner(),

--- a/app/src/main/java/com/helio/app/ui/blinds/BlindsSettingsFragment.java
+++ b/app/src/main/java/com/helio/app/ui/blinds/BlindsSettingsFragment.java
@@ -23,7 +23,7 @@ public class BlindsSettingsFragment extends Fragment {
         View view = inflater.inflate(R.layout.fragment_blinds_settings, container, false);
         BlindsRecViewAdapter adapter = new BlindsRecViewAdapter(getContext(), this);
 
-        UserDataViewModel model = new ViewModelProvider(this).get(UserDataViewModel.class);
+        UserDataViewModel model = new ViewModelProvider(requireActivity()).get(UserDataViewModel.class);
         model.fetchMotors().observe(
                 getViewLifecycleOwner(),
                 motors -> adapter.setMotors(new ArrayList<>(motors.values()))

--- a/app/src/main/java/com/helio/app/ui/blinds/BlindsSettingsFragment.java
+++ b/app/src/main/java/com/helio/app/ui/blinds/BlindsSettingsFragment.java
@@ -21,9 +21,8 @@ public class BlindsSettingsFragment extends Fragment {
     public View onCreateView(@NonNull LayoutInflater inflater,
                              ViewGroup container, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.fragment_blinds_settings, container, false);
-        BlindsRecViewAdapter adapter = new BlindsRecViewAdapter(getContext(), this);
-
         UserDataViewModel model = new ViewModelProvider(requireActivity()).get(UserDataViewModel.class);
+        BlindsRecViewAdapter adapter = new BlindsRecViewAdapter(getContext(), model);
         model.fetchMotors().observe(
                 getViewLifecycleOwner(),
                 motors -> adapter.setMotors(new ArrayList<>(motors.values()))

--- a/app/src/main/java/com/helio/app/ui/blinds/BlindsSettingsFragment.java
+++ b/app/src/main/java/com/helio/app/ui/blinds/BlindsSettingsFragment.java
@@ -25,9 +25,10 @@ public class BlindsSettingsFragment extends Fragment {
 
         UserDataViewModel model = new ViewModelProvider(this).get(UserDataViewModel.class);
 
-        model.fetchMotors().observe(getViewLifecycleOwner(), motors -> {
-            adapter.setMotors(new ArrayList<>(motors.values()));
-        });
+        model.fetchMotors().observe(
+                getViewLifecycleOwner(),
+                motors -> adapter.setMotors(new ArrayList<>(motors.values()))
+        );
 
         // Insert into the recycler view
         RecyclerView recView = view.findViewById(R.id.blindsRCView);

--- a/app/src/main/java/com/helio/app/ui/blinds/BlindsSettingsFragment.java
+++ b/app/src/main/java/com/helio/app/ui/blinds/BlindsSettingsFragment.java
@@ -21,10 +21,9 @@ public class BlindsSettingsFragment extends Fragment {
     public View onCreateView(@NonNull LayoutInflater inflater,
                              ViewGroup container, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.fragment_blinds_settings, container, false);
-        BlindsRecViewAdapter adapter = new BlindsRecViewAdapter(getContext());
+        BlindsRecViewAdapter adapter = new BlindsRecViewAdapter(getContext(), this);
 
         UserDataViewModel model = new ViewModelProvider(this).get(UserDataViewModel.class);
-
         model.fetchMotors().observe(
                 getViewLifecycleOwner(),
                 motors -> adapter.setMotors(new ArrayList<>(motors.values()))

--- a/app/src/main/java/com/helio/app/ui/blinds/BlindsSettingsFragment.java
+++ b/app/src/main/java/com/helio/app/ui/blinds/BlindsSettingsFragment.java
@@ -7,12 +7,12 @@ import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
+import androidx.lifecycle.ViewModelProvider;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.helio.app.R;
-import com.helio.app.model.Motor;
-import com.helio.app.ui.MotorIcon;
+import com.helio.app.UserDataViewModel;
 
 import java.util.ArrayList;
 
@@ -21,17 +21,13 @@ public class BlindsSettingsFragment extends Fragment {
     public View onCreateView(@NonNull LayoutInflater inflater,
                              ViewGroup container, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.fragment_blinds_settings, container, false);
-
-        // Prepare the list of motors TODO (temporary)
-        ArrayList<Motor> motors = new ArrayList<>();
-        motors.add(new Motor("Bedroom", MotorIcon.BEDROOM));
-        motors.add(new Motor("Kitchen", MotorIcon.KITCHEN));
-        motors.add(new Motor("Next to TV", MotorIcon.TV));
-        motors.add(new Motor("Living room", MotorIcon.HOUSE));
-
-        // Setup the adapter with the motors
         BlindsRecViewAdapter adapter = new BlindsRecViewAdapter(getContext());
-        adapter.setMotors(motors);
+
+        UserDataViewModel model = new ViewModelProvider(this).get(UserDataViewModel.class);
+
+        model.fetchMotors().observe(getViewLifecycleOwner(), motors -> {
+            adapter.setMotors(new ArrayList<>(motors.values()));
+        });
 
         // Insert into the recycler view
         RecyclerView recView = view.findViewById(R.id.blindsRCView);

--- a/app/src/main/java/com/helio/app/ui/control/ControlFragment.java
+++ b/app/src/main/java/com/helio/app/ui/control/ControlFragment.java
@@ -26,7 +26,7 @@ public class ControlFragment extends Fragment {
         controlViewModel =
                 new ViewModelProvider(this).get(ControlViewModel.class);
         View view = inflater.inflate(R.layout.fragment_control, container, false);
-        model = new ViewModelProvider(requireActivity()).get(UserDataViewModel.class);
+        model = new ViewModelProvider(this).get(UserDataViewModel.class);
         ControlRecViewAdapter adapter = new ControlRecViewAdapter(getContext(), model);
         model.fetchMotors().observe(
                 getViewLifecycleOwner(),

--- a/app/src/main/java/com/helio/app/ui/control/ControlFragment.java
+++ b/app/src/main/java/com/helio/app/ui/control/ControlFragment.java
@@ -12,6 +12,7 @@ import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.helio.app.R;
+import com.helio.app.UserDataViewModel;
 import com.helio.app.model.Motor;
 import com.helio.app.ui.MotorIcon;
 
@@ -26,17 +27,15 @@ public class ControlFragment extends Fragment {
         controlViewModel =
                 new ViewModelProvider(this).get(ControlViewModel.class);
         View view = inflater.inflate(R.layout.fragment_control, container, false);
-
-        // Prepare the list of motors TODO (temporary)
-        ArrayList<Motor> motors = new ArrayList<>();
-        motors.add(new Motor("Bedroom", MotorIcon.BEDROOM));
-        motors.add(new Motor("Kitchen", MotorIcon.KITCHEN));
-        motors.add(new Motor("Next to TV", MotorIcon.TV));
-        motors.add(new Motor("Living room", MotorIcon.HOUSE));
-
-        // Setup the adapter with the motors
         ControlRecViewAdapter adapter = new ControlRecViewAdapter(getContext());
-        adapter.setMotors(motors);
+
+        UserDataViewModel model = new ViewModelProvider(requireActivity()).get(UserDataViewModel.class);
+        model.fetchMotors().observe(
+                getViewLifecycleOwner(),
+                motors -> adapter.setMotors(new ArrayList<>(motors.values()))
+        );
+
+
 
         // Insert into the recycler view
         RecyclerView recView = view.findViewById(R.id.control_rc_view);

--- a/app/src/main/java/com/helio/app/ui/control/ControlFragment.java
+++ b/app/src/main/java/com/helio/app/ui/control/ControlFragment.java
@@ -13,8 +13,6 @@ import androidx.recyclerview.widget.RecyclerView;
 
 import com.helio.app.R;
 import com.helio.app.UserDataViewModel;
-import com.helio.app.model.Motor;
-import com.helio.app.ui.MotorIcon;
 
 import java.util.ArrayList;
 

--- a/app/src/main/java/com/helio/app/ui/control/ControlFragment.java
+++ b/app/src/main/java/com/helio/app/ui/control/ControlFragment.java
@@ -19,15 +19,15 @@ import java.util.ArrayList;
 public class ControlFragment extends Fragment {
 
     private ControlViewModel controlViewModel;
+    private UserDataViewModel model;
 
     public View onCreateView(@NonNull LayoutInflater inflater,
                              ViewGroup container, Bundle savedInstanceState) {
         controlViewModel =
                 new ViewModelProvider(this).get(ControlViewModel.class);
         View view = inflater.inflate(R.layout.fragment_control, container, false);
-        ControlRecViewAdapter adapter = new ControlRecViewAdapter(getContext());
-
-        UserDataViewModel model = new ViewModelProvider(requireActivity()).get(UserDataViewModel.class);
+        model = new ViewModelProvider(requireActivity()).get(UserDataViewModel.class);
+        ControlRecViewAdapter adapter = new ControlRecViewAdapter(getContext(), model);
         model.fetchMotors().observe(
                 getViewLifecycleOwner(),
                 motors -> adapter.setMotors(new ArrayList<>(motors.values()))

--- a/app/src/main/java/com/helio/app/ui/control/ControlRecViewAdapter.java
+++ b/app/src/main/java/com/helio/app/ui/control/ControlRecViewAdapter.java
@@ -68,13 +68,13 @@ public class ControlRecViewAdapter extends RecyclerView.Adapter<ControlRecViewAd
             @Override
             public void onStopTrackingTouch(@NonNull Slider slider) {
                 Motor motor = motors.get(position);
-                // disable dragging TODO
+                // disable dragging? TODO
                 // send update to Hub
                 motor.setLevel((int) slider.getValue());
                 System.out.println("Updated level using slider: " + motor);
                 model.setCurrentMotor(motor.getId());
                 model.pushCurrentMotorState(motor);
-                // asynchronously enable dragging TODO
+                // asynchronously enable dragging? TODO
             }
         });
     }

--- a/app/src/main/java/com/helio/app/ui/control/ControlRecViewAdapter.java
+++ b/app/src/main/java/com/helio/app/ui/control/ControlRecViewAdapter.java
@@ -8,10 +8,12 @@ import android.widget.ImageView;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
+import androidx.lifecycle.ViewModelProvider;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.google.android.material.slider.Slider;
 import com.helio.app.R;
+import com.helio.app.UserDataViewModel;
 import com.helio.app.model.Motor;
 
 import java.text.NumberFormat;
@@ -19,10 +21,12 @@ import java.util.ArrayList;
 
 public class ControlRecViewAdapter extends RecyclerView.Adapter<ControlRecViewAdapter.ViewHolder> {
     private final Context context;
+    private final UserDataViewModel model;
     private ArrayList<Motor> motors = new ArrayList<>();
 
-    public ControlRecViewAdapter(Context context) {
+    public ControlRecViewAdapter(Context context, UserDataViewModel model) {
         this.context = context;
+        this.model = model;
     }
 
 
@@ -63,7 +67,14 @@ public class ControlRecViewAdapter extends RecyclerView.Adapter<ControlRecViewAd
 
             @Override
             public void onStopTrackingTouch(@NonNull Slider slider) {
-                motors.get(position).setLevel((int) slider.getValue());
+                Motor motor = motors.get(position);
+                // disable dragging TODO
+                // send update to Hub
+                motor.setLevel((int) slider.getValue());
+                System.out.println("Updated level using slider: " + motor);
+                model.setCurrentMotor(motor.getId());
+                model.pushCurrentMotorState(motor);
+                // asynchronously enable dragging TODO
             }
         });
     }

--- a/app/src/main/java/com/helio/app/ui/control/ControlRecViewAdapter.java
+++ b/app/src/main/java/com/helio/app/ui/control/ControlRecViewAdapter.java
@@ -36,9 +36,12 @@ public class ControlRecViewAdapter extends RecyclerView.Adapter<ControlRecViewAd
     @Override
     public void onBindViewHolder(@NonNull ControlRecViewAdapter.ViewHolder holder, int position) {
         // Set the name and icon of the motor and put the current level in the slider
-        holder.txtName.setText(motors.get(position).getName());
-        holder.blindIcon.setImageResource(motors.get(position).getIcon().id);
-        holder.slider.setValue(motors.get(position).getLevel());
+        Motor motor = motors.get(position);
+        holder.txtName.setText(motor.getName());
+        if(motor.getIcon() != null) {
+            holder.blindIcon.setImageResource(motor.getIcon().id);
+        }
+        holder.slider.setValue(motor.getLevel());
 
         // Format the number as a percentage (possibly sensitive to Locale)
         // Display Closed or Open if completely closed or open

--- a/app/src/main/res/navigation/main_navigation.xml
+++ b/app/src/main/res/navigation/main_navigation.xml
@@ -28,5 +28,11 @@
         android:id="@+id/singleBlindSettingsFragment"
         android:name="com.helio.app.ui.blind.SingleBlindSettingsFragment"
         android:label="@string/title_edit_blind"
-        tools:layout="@layout/fragment_single_blind_settings" />
+        tools:layout="@layout/fragment_single_blind_settings">
+
+        <argument
+            android:name="currentMotorId"
+            app:argType="integer"
+            android:defaultValue="0"/>
+    </fragment>
 </navigation>

--- a/app/src/main/res/xml/single_blind_preferences.xml
+++ b/app/src/main/res/xml/single_blind_preferences.xml
@@ -17,7 +17,7 @@
     <ListPreference
         andriod:entries="@array/icons"
         andriod:entryValues="@array/iconsValues"
-        andriod:key="changeIcon"
+        andriod:key="icon"
         andriod:title="@string/settingsIcon"
         app:useSimpleSummaryProvider="true" />
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,9 @@ buildscript {
     dependencies {
         classpath "com.android.tools.build:gradle:4.1.2"
 
+        // used to pass data between fragments
+        classpath "androidx.navigation:navigation-safe-args-gradle-plugin:2.3.3"
+
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }


### PR DESCRIPTION
This PR connects the UI to our app-side back-end:

1) When the user navigates to "blinds control" or "blinds settings" fragments, the Hub is queried to fetch the newest state of the user's motors.
2) When the user navigates to one of the blinds in the "blinds settings" fragment, the ID of that motor is passed to the "single blind settings" fragment using safeargs.
3) When the "open" and "close" buttons are clicked, the appropriate requests are sent to the Hub.
4) Similarly on the "blinds control" page, adjusting the sliders for any of the motors sends the Hub a request to update the state of the respective motor in its database.

As a side effect of these changes, the dummy request code and the dummy motors have become redundant, so they have been removed.

NB1: on the "single blind settings" page, the values of the `Preference`s are incorrect. As mentioned on Teams I don't know how to proceed here. I need some help from either @Jeremy-hao or @adamb56789 to display the correct values there, but I can still make a recording for demo 2 without this.
NB2: blind icons are not working yet - because the Hub does not include these in its responses. this will be resolved after demo 2.

Closes #73
Closes #60