### PR TITLE
UI tests schedule fragment

### DIFF
--- a/app/src/androidTest/java/com/helio/app/TestSchedule.kt
+++ b/app/src/androidTest/java/com/helio/app/TestSchedule.kt
@@ -1,0 +1,133 @@
+package com.helio.app
+
+import android.view.View
+import androidx.recyclerview.widget.RecyclerView
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.UiController
+import androidx.test.espresso.ViewAction
+import androidx.test.espresso.action.ViewActions
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.contrib.RecyclerViewActions.actionOnItemAtPosition
+
+import org.hamcrest.Matcher
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+import androidx.test.espresso.matcher.BoundedMatcher
+import androidx.test.espresso.matcher.ViewMatchers
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+
+import com.google.android.material.slider.Slider
+import com.helio.app.Utils.atPosition
+import org.hamcrest.Description
+import org.junit.Before
+
+@RunWith(AndroidJUnit4::class)
+@LargeTest
+class TestSchedule {
+
+    @get:Rule
+    var activityRule: ActivityScenarioRule<MainActivity>
+            = ActivityScenarioRule(MainActivity::class.java)
+
+    @Before
+    fun setup() {
+        // navigate to the desired fragment
+        onView(withId(R.id.navigation_schedule))
+                .perform(ViewActions.click())
+    }
+
+    @Test
+    // check that we can activate the switch for schedule #1
+    fun activateSwitch0() {
+        // TODO: ensure the switch starts out in deactivated state
+        onView(withId(R.id.schedulesRCView))
+                .perform(actionOnItemAtPosition<RecyclerView.ViewHolder>
+                (0, clickOnViewChild(R.id.activate_switch)))
+    }
+
+    @Test
+    // check that we can adjust multiple sliders
+    fun adjustMultipleSliders() {
+        val slider1Position = 0
+        val slider2Position = 1
+        val slider1ExpectedValue = 100.0F
+        val slider2ExpectedValue = 33.0F
+        // adjust slider 1 to 100%
+        onView(withId(R.id.control_rc_view))
+                .perform(actionOnItemAtPosition<RecyclerView.ViewHolder>
+                (slider1Position, setValue(slider1ExpectedValue)))
+        // adjust slider 2 to 33.2%
+        onView(withId(R.id.control_rc_view))
+                .perform(actionOnItemAtPosition<RecyclerView.ViewHolder>
+                (slider2Position, setValue(slider2ExpectedValue)))
+        // verify values match expectations
+        onView(withId(R.id.control_rc_view))
+                .check(matches(atPosition(slider1Position, withValue(slider1ExpectedValue))));
+        onView(withId(R.id.control_rc_view))
+                .check(matches(atPosition(slider2Position, withValue(slider2ExpectedValue))));
+    }
+
+    @Test
+    // check that we can navigate into a single blind settings fragment
+    fun enterBlind0Settings() {
+        onView(withId(R.id.control_rc_view))
+                // click on the icon (instead of the centre) to avoid pressing the slider
+                .perform(actionOnItemAtPosition<RecyclerView.ViewHolder>
+                (0, clickOnViewChild(R.id.blindIcon)))
+        // check that the calibration button is displayed to confirm we're in settings fragment
+        onView(withId(R.id.calibration)).check(matches(ViewMatchers.isDisplayed()))
+    }
+
+    @Test
+    // check that we can add a new blind using the "+"-button
+    fun registerNewBlind() {
+        val startCount = Utils.getCountFromRecyclerView(R.id.control_rc_view)
+        onView(withId(R.id.add_blinds_button))
+                .perform(ViewActions.click())
+        onView(withId(R.id.control_rc_view))
+                .check(matches(Utils.withExpectedCount(startCount + 1)));
+    }
+
+    private fun withValue(expectedValue: Float): Matcher<View?> {
+        return object : BoundedMatcher<View?, View>(View::class.java) {
+            override fun describeTo(description: Description) {
+                description.appendText("expected: $expectedValue")
+            }
+
+            override fun matchesSafely(view: View): Boolean {
+                return view.findViewById<Slider>(R.id.controlSlider).value == expectedValue
+            }
+        }
+    }
+
+    fun setValue(value: Float): ViewAction {
+        return object : ViewAction {
+            override fun getDescription(): String {
+                return "Set Slider value to $value"
+            }
+
+            override fun getConstraints(): Matcher<View> {
+                return ViewMatchers.isAssignableFrom(Slider::class.java)
+            }
+
+            override fun perform(uiController: UiController?, view: View) {
+                val seekBar = view.findViewById(R.id.controlSlider) as Slider
+                seekBar.value = value
+            }
+        }
+    }
+
+    private fun clickOnViewChild(viewId: Int) = object : ViewAction {
+        override fun getConstraints() = null
+
+        override fun getDescription() = "Click on a child view with specified id."
+
+        override fun perform(uiController: UiController, view: View) =
+                ViewActions.click().perform(uiController, view.findViewById<View>(viewId))
+    }
+}

--- a/app/src/androidTest/java/com/helio/app/TestSchedule.kt
+++ b/app/src/androidTest/java/com/helio/app/TestSchedule.kt
@@ -61,11 +61,11 @@ class TestSchedule {
 
     @Test
     // check that we can add a new blind using the "+"-button
-    fun registerNewBlind() {
-        val startCount = Utils.getCountFromRecyclerView(R.id.control_rc_view)
-        onView(withId(R.id.add_blinds_button))
+    fun registerNewSchedule() {
+        val startCount = Utils.getCountFromRecyclerView(R.id.schedulesRCView)
+        onView(withId(R.id.add_button))
                 .perform(ViewActions.click())
-        onView(withId(R.id.control_rc_view))
+        onView(withId(R.id.schedulesRCView))
                 .check(matches(Utils.withExpectedCount(startCount + 1)));
     }
 

--- a/app/src/androidTest/java/com/helio/app/TestSchedule.kt
+++ b/app/src/androidTest/java/com/helio/app/TestSchedule.kt
@@ -69,35 +69,6 @@ class TestSchedule {
                 .check(matches(Utils.withExpectedCount(startCount + 1)));
     }
 
-    private fun withValue(expectedValue: Float): Matcher<View?> {
-        return object : BoundedMatcher<View?, View>(View::class.java) {
-            override fun describeTo(description: Description) {
-                description.appendText("expected: $expectedValue")
-            }
-
-            override fun matchesSafely(view: View): Boolean {
-                return view.findViewById<Slider>(R.id.controlSlider).value == expectedValue
-            }
-        }
-    }
-
-    fun setValue(value: Float): ViewAction {
-        return object : ViewAction {
-            override fun getDescription(): String {
-                return "Set Slider value to $value"
-            }
-
-            override fun getConstraints(): Matcher<View> {
-                return ViewMatchers.isAssignableFrom(Slider::class.java)
-            }
-
-            override fun perform(uiController: UiController?, view: View) {
-                val seekBar = view.findViewById(R.id.controlSlider) as Slider
-                seekBar.value = value
-            }
-        }
-    }
-
     private fun clickOnViewChild(viewId: Int) = object : ViewAction {
         override fun getConstraints() = null
 

--- a/app/src/androidTest/java/com/helio/app/TestSchedule.kt
+++ b/app/src/androidTest/java/com/helio/app/TestSchedule.kt
@@ -72,10 +72,14 @@ class TestSchedule {
                 .perform(actionOnItemAtPosition<RecyclerView.ViewHolder>
                 (0, ViewActions.click()))
         // update this schedule's activate days
-        onView(withId(R.id.day1)).perform(ViewActions.click())
-        onView(withId(R.id.day3)).perform(ViewActions.click())
-        onView(withId(R.id.day4)).perform(ViewActions.click())
-        onView(withId(R.id.day7)).perform(ViewActions.click())
+        onView(withId(R.id.day1))
+                .perform(ViewActions.click())
+        onView(withId(R.id.day3))
+                .perform(ViewActions.click())
+        onView(withId(R.id.day4))
+                .perform(ViewActions.click())
+        onView(withId(R.id.day7))
+                .perform(ViewActions.click())
     }
 
     private fun clickOnViewChild(viewId: Int) = object : ViewAction {

--- a/app/src/androidTest/java/com/helio/app/TestSchedule.kt
+++ b/app/src/androidTest/java/com/helio/app/TestSchedule.kt
@@ -42,6 +42,16 @@ class TestSchedule {
     }
 
     @Test
+    // check that we can add a new blind using the "+"-button
+    fun registerNewSchedule() {
+        val startCount = Utils.getCountFromRecyclerView(R.id.schedulesRCView)
+        onView(withId(R.id.add_button))
+                .perform(ViewActions.click())
+        onView(withId(R.id.schedulesRCView))
+                .check(matches(Utils.withExpectedCount(startCount + 1)));
+    }
+
+    @Test
     // check that we can toggle the switch for schedule #1
     fun toggleSwitch0() {
         onView(withId(R.id.schedulesRCView))
@@ -57,16 +67,6 @@ class TestSchedule {
                 (0, ViewActions.click()))
         // check that the time button is displayed to confirm we're in settings fragment
         onView(withId(R.id.time_button)).check(matches(ViewMatchers.isDisplayed()))
-    }
-
-    @Test
-    // check that we can add a new blind using the "+"-button
-    fun registerNewSchedule() {
-        val startCount = Utils.getCountFromRecyclerView(R.id.schedulesRCView)
-        onView(withId(R.id.add_button))
-                .perform(ViewActions.click())
-        onView(withId(R.id.schedulesRCView))
-                .check(matches(Utils.withExpectedCount(startCount + 1)));
     }
 
     private fun clickOnViewChild(viewId: Int) = object : ViewAction {

--- a/app/src/androidTest/java/com/helio/app/TestSchedule.kt
+++ b/app/src/androidTest/java/com/helio/app/TestSchedule.kt
@@ -50,36 +50,13 @@ class TestSchedule {
     }
 
     @Test
-    // check that we can adjust multiple sliders
-    fun adjustMultipleSliders() {
-        val slider1Position = 0
-        val slider2Position = 1
-        val slider1ExpectedValue = 100.0F
-        val slider2ExpectedValue = 33.0F
-        // adjust slider 1 to 100%
-        onView(withId(R.id.control_rc_view))
+    // check that we can navigate into a single schedule settings fragment
+    fun enterSchedule0Settings() {
+        onView(withId(R.id.schedulesRCView))
                 .perform(actionOnItemAtPosition<RecyclerView.ViewHolder>
-                (slider1Position, setValue(slider1ExpectedValue)))
-        // adjust slider 2 to 33.2%
-        onView(withId(R.id.control_rc_view))
-                .perform(actionOnItemAtPosition<RecyclerView.ViewHolder>
-                (slider2Position, setValue(slider2ExpectedValue)))
-        // verify values match expectations
-        onView(withId(R.id.control_rc_view))
-                .check(matches(atPosition(slider1Position, withValue(slider1ExpectedValue))));
-        onView(withId(R.id.control_rc_view))
-                .check(matches(atPosition(slider2Position, withValue(slider2ExpectedValue))));
-    }
-
-    @Test
-    // check that we can navigate into a single blind settings fragment
-    fun enterBlind0Settings() {
-        onView(withId(R.id.control_rc_view))
-                // click on the icon (instead of the centre) to avoid pressing the slider
-                .perform(actionOnItemAtPosition<RecyclerView.ViewHolder>
-                (0, clickOnViewChild(R.id.blindIcon)))
-        // check that the calibration button is displayed to confirm we're in settings fragment
-        onView(withId(R.id.calibration)).check(matches(ViewMatchers.isDisplayed()))
+                (0, ViewActions.click()))
+        // check that the time button is displayed to confirm we're in settings fragment
+        onView(withId(R.id.time_button)).check(matches(ViewMatchers.isDisplayed()))
     }
 
     @Test

--- a/app/src/androidTest/java/com/helio/app/TestSchedule.kt
+++ b/app/src/androidTest/java/com/helio/app/TestSchedule.kt
@@ -9,21 +9,16 @@ import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.contrib.RecyclerViewActions.actionOnItemAtPosition
 
-import org.hamcrest.Matcher
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
-import androidx.test.espresso.matcher.BoundedMatcher
 import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
 
-import com.google.android.material.slider.Slider
-import com.helio.app.Utils.atPosition
-import org.hamcrest.Description
 import org.junit.Before
 
 @RunWith(AndroidJUnit4::class)

--- a/app/src/androidTest/java/com/helio/app/TestSchedule.kt
+++ b/app/src/androidTest/java/com/helio/app/TestSchedule.kt
@@ -69,6 +69,20 @@ class TestSchedule {
         onView(withId(R.id.time_button)).check(matches(ViewMatchers.isDisplayed()))
     }
 
+    @Test
+    // check that we can update a schedule's activate days
+    fun adjustSchedule0ActiveDays() {
+        // enter the settings fragment for this schedule
+        onView(withId(R.id.schedulesRCView))
+                .perform(actionOnItemAtPosition<RecyclerView.ViewHolder>
+                (0, ViewActions.click()))
+        // update this schedule's activate days
+        onView(withId(R.id.day1)).perform(ViewActions.click())
+        onView(withId(R.id.day3)).perform(ViewActions.click())
+        onView(withId(R.id.day4)).perform(ViewActions.click())
+        onView(withId(R.id.day7)).perform(ViewActions.click())
+    }
+
     private fun clickOnViewChild(viewId: Int) = object : ViewAction {
         override fun getConstraints() = null
 

--- a/app/src/androidTest/java/com/helio/app/TestSchedule.kt
+++ b/app/src/androidTest/java/com/helio/app/TestSchedule.kt
@@ -42,9 +42,8 @@ class TestSchedule {
     }
 
     @Test
-    // check that we can activate the switch for schedule #1
-    fun activateSwitch0() {
-        // TODO: ensure the switch starts out in deactivated state
+    // check that we can toggle the switch for schedule #1
+    fun toggleSwitch0() {
         onView(withId(R.id.schedulesRCView))
                 .perform(actionOnItemAtPosition<RecyclerView.ViewHolder>
                 (0, clickOnViewChild(R.id.activate_switch)))

--- a/app/src/androidTest/java/com/helio/app/Utils.java
+++ b/app/src/androidTest/java/com/helio/app/Utils.java
@@ -7,9 +7,13 @@ import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
 import androidx.test.espresso.matcher.BoundedMatcher;
 
+import com.google.android.material.switchmaterial.SwitchMaterial;
+
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
+
+import java.util.Objects;
 
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
@@ -59,7 +63,7 @@ public class Utils {
         Matcher<View> matcher = new TypeSafeMatcher<View>() {
             @Override
             protected boolean matchesSafely(View item) {
-                COUNT[0] = ((RecyclerView) item).getAdapter().getItemCount();
+                COUNT[0] = Objects.requireNonNull(((RecyclerView) item).getAdapter()).getItemCount();
                 return true;
             }
             @Override


### PR DESCRIPTION
Add UI tests for the schedule fragment:
- register a new schedule
- toggle the switch for a new schedule
- enter the single schedule settings fragment
- adjust the active days for a schedule