### PR TITLE
Calibration requests

### DIFF
--- a/app/src/main/java/com/helio/app/UserDataViewModel.java
+++ b/app/src/main/java/com/helio/app/UserDataViewModel.java
@@ -4,6 +4,7 @@ import android.app.Application;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.res.Resources;
+import android.os.Handler;
 import android.speech.tts.TextToSpeech;
 import android.widget.Toast;
 
@@ -18,6 +19,7 @@ import com.helio.app.model.MotionSensor;
 import com.helio.app.model.Motor;
 import com.helio.app.model.Schedule;
 import com.helio.app.model.Sensor;
+import com.helio.app.networking.CalibrationIntervalManager;
 import com.helio.app.networking.HubClient;
 import com.helio.app.networking.IPAddress;
 import com.helio.app.networking.NetworkStatus;
@@ -39,11 +41,13 @@ public class UserDataViewModel extends AndroidViewModel {
     private MutableLiveData<Map<Integer, Schedule>> schedules;
     private MutableLiveData<Map<Integer, LightSensor>> lightSensors;
     private MutableLiveData<Map<Integer, MotionSensor>> motionSensors;
+    private CalibrationIntervalManager calibrationIntervalManager;
 
     public UserDataViewModel(@NonNull Application application) {
         super(application);
         sharedPrefs = getApplication().getSharedPreferences("Preferences", Context.MODE_PRIVATE);
         client = createClient(getHubIp());
+        calibrationIntervalManager = new CalibrationIntervalManager(client);
     }
 
     public static String removeTrailingSpaces(String param) {
@@ -239,7 +243,7 @@ public class UserDataViewModel extends AndroidViewModel {
     }
 
     public void moveUp(Motor motor) {
-        client.moveUp(motor);
+        calibrationIntervalManager.startRequestLoop(motor);
     }
 
     public void moveDown(Motor motor) {
@@ -247,7 +251,7 @@ public class UserDataViewModel extends AndroidViewModel {
     }
 
     public void stopMoving(Motor motor) {
-        client.stopMoving(motor);
+        calibrationIntervalManager.stopRequestLoop();
     }
 
     public void setHighestPoint(Motor motor) {

--- a/app/src/main/java/com/helio/app/UserDataViewModel.java
+++ b/app/src/main/java/com/helio/app/UserDataViewModel.java
@@ -40,7 +40,7 @@ public class UserDataViewModel extends AndroidViewModel {
     private MutableLiveData<Map<Integer, Schedule>> schedules;
     private MutableLiveData<Map<Integer, LightSensor>> lightSensors;
     private MutableLiveData<Map<Integer, MotionSensor>> motionSensors;
-    private CalibrationIntervalManager calibrationIntervalManager;
+    private final CalibrationIntervalManager calibrationIntervalManager;
 
     public UserDataViewModel(@NonNull Application application) {
         super(application);
@@ -246,7 +246,7 @@ public class UserDataViewModel extends AndroidViewModel {
     }
 
     public void moveDown(Motor motor) {
-        client.moveDown(motor);
+        calibrationIntervalManager.startMoveDownRequestLoop(motor);
     }
 
     public void stopMoving(Motor motor) {

--- a/app/src/main/java/com/helio/app/UserDataViewModel.java
+++ b/app/src/main/java/com/helio/app/UserDataViewModel.java
@@ -4,7 +4,6 @@ import android.app.Application;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.res.Resources;
-import android.os.Handler;
 import android.speech.tts.TextToSpeech;
 import android.widget.Toast;
 
@@ -243,7 +242,7 @@ public class UserDataViewModel extends AndroidViewModel {
     }
 
     public void moveUp(Motor motor) {
-        calibrationIntervalManager.startRequestLoop(motor);
+        calibrationIntervalManager.startMoveUpRequestLoop(motor);
     }
 
     public void moveDown(Motor motor) {

--- a/app/src/main/java/com/helio/app/UserDataViewModel.java
+++ b/app/src/main/java/com/helio/app/UserDataViewModel.java
@@ -249,7 +249,7 @@ public class UserDataViewModel extends AndroidViewModel {
         calibrationIntervalManager.startMoveDownRequestLoop(motor);
     }
 
-    public void stopMoving(Motor motor) {
+    public void stopMoving() {
         calibrationIntervalManager.stopRequestLoop();
     }
 

--- a/app/src/main/java/com/helio/app/networking/CalibrationIntervalManager.java
+++ b/app/src/main/java/com/helio/app/networking/CalibrationIntervalManager.java
@@ -1,0 +1,45 @@
+package com.helio.app.networking;
+
+import android.os.Handler;
+
+import com.helio.app.model.Motor;
+
+public class CalibrationIntervalManager {
+    private static final int CALIBRATION_INTERVAL_DELAY = 1000;
+    private final Handler calibrationIntervalHandler;
+    private final HubClient client;
+    private Runnable pendingRunnable = null;
+    private Motor targetMotor = null;
+
+    public CalibrationIntervalManager(HubClient client) {
+        this.client = client;
+        this.calibrationIntervalHandler = new Handler();
+    }
+
+    private void sendSingleMoveUpRequest(Motor motor) {
+        System.out.println("CALIBRATION: \tsending one move_up request...");
+    }
+
+    public void startRequestLoop(Motor motor) {
+        System.out.println("CALIBRATION: setting up move_up request loop...");
+        // set up a handler that calls itself
+        pendingRunnable = new Runnable() {
+            @Override
+            public void run() {
+                sendSingleMoveUpRequest(motor);
+                calibrationIntervalHandler.postDelayed(this, CALIBRATION_INTERVAL_DELAY);
+            }
+        };
+        calibrationIntervalHandler.postDelayed(pendingRunnable, 0);
+    }
+
+    public void stopRequestLoop() {
+        if(targetMotor == null || pendingRunnable == null) {
+            throw new IllegalStateException("Cannot stop calibration loop when either targetMotor" +
+                    " or pendingRunnable is null.");
+        }
+        System.out.println("CALIBRATION: stopping calibration request loop...");
+        calibrationIntervalHandler.removeCallbacks(pendingRunnable);
+        pendingRunnable = null;
+    }
+}

--- a/app/src/main/java/com/helio/app/networking/CalibrationIntervalManager.java
+++ b/app/src/main/java/com/helio/app/networking/CalibrationIntervalManager.java
@@ -18,21 +18,22 @@ public class CalibrationIntervalManager {
         state = CalibrationIntervalManagerState.IDLE;
     }
 
-    private void sendSingleMoveUpRequest(Motor motor) {
+    private void sendSingleMoveUpRequest() {
         System.out.println("CALIBRATION: \tsending one move_up request...");
     }
 
-    public void startRequestLoop(Motor motor) {
+    public void startMoveUpRequestLoop(Motor motor) {
+        System.out.println("CALIBRATION: setting up move_up request loop...");
         if(state != CalibrationIntervalManagerState.IDLE) {
             throw new IllegalStateException("Cannot start move up unless current state is IDLE.");
         }
         state = CalibrationIntervalManagerState.MOVING_UP;
-        System.out.println("CALIBRATION: setting up move_up request loop...");
+        targetMotor = motor;
         // set up a handler that calls itself
         pendingRunnable = new Runnable() {
             @Override
             public void run() {
-                sendSingleMoveUpRequest(motor);
+                sendSingleMoveUpRequest();
                 calibrationIntervalHandler.postDelayed(this, CALIBRATION_INTERVAL_DELAY);
             }
         };
@@ -40,12 +41,12 @@ public class CalibrationIntervalManager {
     }
 
     public void stopRequestLoop() {
+        System.out.println("CALIBRATION: stopping calibration request loop...");
         if(state != CalibrationIntervalManagerState.MOVING_DOWN ||
                 state != CalibrationIntervalManagerState.MOVING_DOWN) {
             throw new IllegalStateException("Cannot stop loop without being in MOVING_UP or " +
                     "MOVING_DOWN state.");
         }
-        System.out.println("CALIBRATION: stopping calibration request loop...");
         calibrationIntervalHandler.removeCallbacks(pendingRunnable);
         pendingRunnable = null;
         targetMotor = null;

--- a/app/src/main/java/com/helio/app/networking/CalibrationIntervalManager.java
+++ b/app/src/main/java/com/helio/app/networking/CalibrationIntervalManager.java
@@ -20,10 +20,12 @@ public class CalibrationIntervalManager {
 
     private void sendSingleMoveUpRequest() {
         System.out.println("CALIBRATION: \tsending one move_up request...");
+        client.moveUp(targetMotor);
     }
 
     private void sendSingleMoveDownRequest() {
         System.out.println("CALIBRATION: \tsending one move_down request...");
+        client.moveDown(targetMotor);
     }
 
     public void startMoveUpRequestLoop(Motor motor) {
@@ -70,6 +72,7 @@ public class CalibrationIntervalManager {
                     "MOVING_DOWN state.");
         }
         calibrationIntervalHandler.removeCallbacks(pendingRunnable);
+        client.stopMoving(targetMotor);
         pendingRunnable = null;
         targetMotor = null;
         state = CalibrationIntervalManagerState.IDLE;

--- a/app/src/main/java/com/helio/app/networking/CalibrationIntervalManager.java
+++ b/app/src/main/java/com/helio/app/networking/CalibrationIntervalManager.java
@@ -49,7 +49,7 @@ public class CalibrationIntervalManager {
     public void startMoveDownRequestLoop(Motor motor) {
         System.out.println("CALIBRATION: setting up move_down request loop...");
         if(state != CalibrationIntervalManagerState.IDLE) {
-            throw new IllegalStateException("Cannot start move down unless current state is IDLE.");
+            return;
         }
         state = CalibrationIntervalManagerState.MOVING_DOWN;
         targetMotor = motor;
@@ -68,8 +68,7 @@ public class CalibrationIntervalManager {
         System.out.println("CALIBRATION: stopping calibration request loop...");
         if(!(state == CalibrationIntervalManagerState.MOVING_UP ||
                 state == CalibrationIntervalManagerState.MOVING_DOWN)) {
-            throw new IllegalStateException("Cannot stop loop without being in MOVING_UP or " +
-                    "MOVING_DOWN state.");
+            return;
         }
         calibrationIntervalHandler.removeCallbacks(pendingRunnable);
         client.stopMoving(targetMotor);

--- a/app/src/main/java/com/helio/app/networking/CalibrationIntervalManager.java
+++ b/app/src/main/java/com/helio/app/networking/CalibrationIntervalManager.java
@@ -1,7 +1,5 @@
 package com.helio.app.networking;
 
-import android.os.Handler;
-
 import com.helio.app.model.Motor;
 
 import java.util.concurrent.Executors;
@@ -12,7 +10,6 @@ import java.util.concurrent.TimeUnit;
 public class CalibrationIntervalManager {
     private CalibrationIntervalManagerState state;
     private static final int CALIBRATION_INTERVAL_DELAY = 1000;
-    private final Handler calibrationIntervalHandler;
     private final HubClient client;
     private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
     private ScheduledFuture<?> requestsLoopHandle = null;
@@ -20,7 +17,6 @@ public class CalibrationIntervalManager {
 
     public CalibrationIntervalManager(HubClient client) {
         this.client = client;
-        this.calibrationIntervalHandler = new Handler();
         state = CalibrationIntervalManagerState.IDLE;
     }
 

--- a/app/src/main/java/com/helio/app/networking/CalibrationIntervalManager.java
+++ b/app/src/main/java/com/helio/app/networking/CalibrationIntervalManager.java
@@ -22,6 +22,10 @@ public class CalibrationIntervalManager {
         System.out.println("CALIBRATION: \tsending one move_up request...");
     }
 
+    private void sendSingleMoveDownRequest() {
+        System.out.println("CALIBRATION: \tsending one move_down request...");
+    }
+
     public void startMoveUpRequestLoop(Motor motor) {
         System.out.println("CALIBRATION: setting up move_up request loop...");
         if(state != CalibrationIntervalManagerState.IDLE) {
@@ -40,10 +44,28 @@ public class CalibrationIntervalManager {
         calibrationIntervalHandler.postDelayed(pendingRunnable, 0);
     }
 
+    public void startMoveDownRequestLoop(Motor motor) {
+        System.out.println("CALIBRATION: setting up move_down request loop...");
+        if(state != CalibrationIntervalManagerState.IDLE) {
+            throw new IllegalStateException("Cannot start move down unless current state is IDLE.");
+        }
+        state = CalibrationIntervalManagerState.MOVING_DOWN;
+        targetMotor = motor;
+        // set up a handler that calls itself
+        pendingRunnable = new Runnable() {
+            @Override
+            public void run() {
+                sendSingleMoveDownRequest();
+                calibrationIntervalHandler.postDelayed(this, CALIBRATION_INTERVAL_DELAY);
+            }
+        };
+        calibrationIntervalHandler.postDelayed(pendingRunnable, 0);
+    }
+
     public void stopRequestLoop() {
         System.out.println("CALIBRATION: stopping calibration request loop...");
-        if(state != CalibrationIntervalManagerState.MOVING_DOWN ||
-                state != CalibrationIntervalManagerState.MOVING_DOWN) {
+        if(!(state == CalibrationIntervalManagerState.MOVING_UP ||
+                state == CalibrationIntervalManagerState.MOVING_DOWN)) {
             throw new IllegalStateException("Cannot stop loop without being in MOVING_UP or " +
                     "MOVING_DOWN state.");
         }

--- a/app/src/main/java/com/helio/app/networking/CalibrationIntervalManager.java
+++ b/app/src/main/java/com/helio/app/networking/CalibrationIntervalManager.java
@@ -30,7 +30,7 @@ public class CalibrationIntervalManager {
 
     public void startMoveUpRequestLoop(Motor motor) {
         System.out.println("CALIBRATION: setting up move_up request loop...");
-        if(state != CalibrationIntervalManagerState.IDLE) {
+        if (state != CalibrationIntervalManagerState.IDLE) {
             throw new IllegalStateException("Cannot start move up unless current state is IDLE.");
         }
         state = CalibrationIntervalManagerState.MOVING_UP;
@@ -48,7 +48,7 @@ public class CalibrationIntervalManager {
 
     public void startMoveDownRequestLoop(Motor motor) {
         System.out.println("CALIBRATION: setting up move_down request loop...");
-        if(state != CalibrationIntervalManagerState.IDLE) {
+        if (state != CalibrationIntervalManagerState.IDLE) {
             return;
         }
         state = CalibrationIntervalManagerState.MOVING_DOWN;
@@ -66,7 +66,7 @@ public class CalibrationIntervalManager {
 
     public void stopRequestLoop() {
         System.out.println("CALIBRATION: stopping calibration request loop...");
-        if(!(state == CalibrationIntervalManagerState.MOVING_UP ||
+        if (!(state == CalibrationIntervalManagerState.MOVING_UP ||
                 state == CalibrationIntervalManagerState.MOVING_DOWN)) {
             return;
         }

--- a/app/src/main/java/com/helio/app/networking/CalibrationIntervalManagerState.java
+++ b/app/src/main/java/com/helio/app/networking/CalibrationIntervalManagerState.java
@@ -1,7 +1,6 @@
 package com.helio.app.networking;
 
 public enum CalibrationIntervalManagerState {
-    BUSY,
     IDLE,
     MOVING_UP,
     MOVING_DOWN;

--- a/app/src/main/java/com/helio/app/networking/CalibrationIntervalManagerState.java
+++ b/app/src/main/java/com/helio/app/networking/CalibrationIntervalManagerState.java
@@ -1,0 +1,8 @@
+package com.helio.app.networking;
+
+public enum CalibrationIntervalManagerState {
+    BUSY,
+    IDLE,
+    MOVING_UP,
+    MOVING_DOWN;
+}

--- a/app/src/main/java/com/helio/app/ui/blinds/CalibrationFragment.java
+++ b/app/src/main/java/com/helio/app/ui/blinds/CalibrationFragment.java
@@ -44,7 +44,7 @@ public class CalibrationFragment extends Fragment {
                         if (event.getAction() == MotionEvent.ACTION_DOWN) {
                             model.moveUp(motor);
                         } else if (event.getAction() == MotionEvent.ACTION_UP) {
-                            model.stopMoving(motor);
+                            model.stopMoving();
                         }
                         v.performClick();
                         return false;
@@ -53,7 +53,7 @@ public class CalibrationFragment extends Fragment {
                         if (event.getAction() == MotionEvent.ACTION_DOWN) {
                             model.moveDown(motor);
                         } else if (event.getAction() == MotionEvent.ACTION_UP) {
-                            model.stopMoving(motor);
+                            model.stopMoving();
                         }
                         v.performClick();
                         return false;
@@ -70,7 +70,7 @@ public class CalibrationFragment extends Fragment {
     public void onStop() {
         if (model != null) {
             // Stop calibration upon page closing
-            model.stopMoving(motor);
+            model.stopMoving();
             model.stopCalibration(motor);
             Toast.makeText(requireContext(), requireContext().getString(R.string.calibrated_message), Toast.LENGTH_SHORT).show();
         }


### PR DESCRIPTION
Closes #158 
This is a workaround for the fact that the Hub can't loop on its own right now. It would be a lot cleaner if we sent one `move_{up,down}` request from the app when the user presses the button, upon which the Hub handles the interval.